### PR TITLE
Version 5.0.3: Fix one compliation bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,10 @@
 
 CD-HIT ChangeLog
 
-CD-HIT-V5.0 (2021-07-12) modified by wym6912:
+CD-HIT-V5.0.3 (2021-12-29) modified by wym6912:
+Add -std=c++11 on compling files
+
+CD-HIT-V5.0.2 (2021-07-12) modified by wym6912:
 Now the program has the modules: cd-hit, cd-hit-est, cd-hit-454
 
 CD-HIT-V4.8.1 (2019-03-01):

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ else
   CCFLAGS = -fopenmp
 endif
 
+# prevent `to_string` complie error
+CCFLAGS += -std=c++11
+
 #LDFLAGS = -static -lz -o
 #LDFLAGS = /usr/lib/x86_64-linux-gnu/libz.a -o
 

--- a/cdhit-common.h
+++ b/cdhit-common.h
@@ -43,7 +43,7 @@
 #include<vector>
 #include<map>
 
-#define CDHIT_VERSION  "5.0.2"
+#define CDHIT_VERSION  "5.0.3"
 
 #ifndef MAX_SEQ
 #define MAX_SEQ 655360


### PR DESCRIPTION
Add `-std=c++11` for `to_string` function.